### PR TITLE
Add scalable stats based on savefile

### DIFF
--- a/scenes/Game.gd
+++ b/scenes/Game.gd
@@ -31,11 +31,12 @@ var specials = []
 var cards = []
 var player_tile = [0, 0]
 var rng
-var health = 3
+var health = 1
 var score = 0
 var hit_lock = false
 var player_dead = false
 
+var save_stats
 
 func _ready():
 	$ChipTimer.start()
@@ -43,6 +44,10 @@ func _ready():
 	$CardTimer.start()
 	rng = RandomNumberGenerator.new()
 	
+	save_stats = Save.pull_stats()
+	health += save_stats["stats"][Save.STAT_INDEX.HEALTH]["count"]
+	update_health()
+
 	player_tile = [6, 3]
 	$Player.position = Vector2(
 		(player_tile[0] + 1.5) * TILE_SIZE,

--- a/scenes/Indicator.gd
+++ b/scenes/Indicator.gd
@@ -5,15 +5,19 @@ extends Node2D
 # var a = 2
 # var b = "text"
 onready var tp = TexturePacks.get_texturepack(TexturePacks.TP_INDEX.DEFAULT_TP)
+onready var save_stats = Save.pull_stats()
 var texture_arr
 onready var sprite = $Sprite
 
-const LERP_SPEED = 0.03
+const LERP_SPEED_MULTIPLIER = 0.01
+var lerp_speed
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
+	visible = false
 	texture_arr = tp.texture_arr
 	sprite.set_scale(Vector2(0.25,0.25))
+	lerp_speed = save_stats["stats"][Save.STAT_INDEX.FADE]["count"] * LERP_SPEED_MULTIPLIER
 	pass # Replace with function body.
 
 func set_value(value):
@@ -23,7 +27,7 @@ func set_value(value):
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta):
-	set_modulate(lerp(get_modulate(), Color(1,1,1,1), LERP_SPEED))
+	set_modulate(lerp(get_modulate(), Color(1,1,1,1), lerp_speed))
 
 func fade_in():
 	if(visible == false):

--- a/scenes/Player.gd
+++ b/scenes/Player.gd
@@ -50,11 +50,16 @@ var texture_arr
 var texture_arr_vflip
 var texture_arr_hflip
 
+var save_stats
+const SPEED_MULTIPLIER = 0.02
+var speed
+
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	screen_size = get_viewport_rect().size
 
-	var save_stats = Save.pull_stats()
+	save_stats = Save.pull_stats()
+	speed = (save_stats["stats"][Save.STAT_INDEX.SPEED]["count"] + 1) * SPEED_MULTIPLIER
 	tp = TexturePacks.get_texturepack(save_stats.texture_pack)
 
 	texture_arr = tp.texture_arr
@@ -69,7 +74,7 @@ func _ready():
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta):
 	if(right_roll_flag):
-		roll_progress = clamp(roll_progress + 0.1, 0, 1.0)
+		roll_progress = clamp(roll_progress + speed, 0, 1.0)
 		set_progress(roll_progress)
 		set_shader(true,false,false,false)
 		if roll_progress == 1.0:
@@ -78,7 +83,7 @@ func _process(delta):
 			roll_progress = 0
 			set_shader(false,false,false,false)
 	elif(left_roll_flag):
-		roll_progress = clamp(roll_progress + 0.1, 0, 1.0)
+		roll_progress = clamp(roll_progress + speed, 0, 1.0)
 		set_progress(roll_progress)
 		set_shader(false,true,false,false)
 		if roll_progress == 1.0:
@@ -87,7 +92,7 @@ func _process(delta):
 			roll_progress = 0
 			set_shader(false,false,false,false)
 	elif(up_roll_flag):
-		roll_progress = clamp(roll_progress + 0.1, 0, 1.0)
+		roll_progress = clamp(roll_progress + speed, 0, 1.0)
 		set_progress(roll_progress)
 		set_shader(false,false,true,false)
 		if roll_progress == 1.0:
@@ -96,7 +101,7 @@ func _process(delta):
 			roll_progress = 0
 			set_shader(false,false,false,false)
 	elif(down_roll_flag):
-		roll_progress = clamp(roll_progress + 0.1, 0, 1.0)
+		roll_progress = clamp(roll_progress + speed, 0, 1.0)
 		set_progress(roll_progress)
 		set_shader(false,false,false,true)
 		if roll_progress == 1.0:


### PR DESCRIPTION
Allows health, indicator fade, and player speed to be scaled based on the save file

Save file access is pretty bad, happening in each scene upon instantiation. Next time we'll make this better